### PR TITLE
do not set pod cpu limits by default

### DIFF
--- a/airflow_spark_on_k8s_job_builder/constants.py
+++ b/airflow_spark_on_k8s_job_builder/constants.py
@@ -73,7 +73,6 @@ SPARK_JOB_SPEC_TEMPLATE = {
         "driver": {
             "serviceAccount": OVERRIDE_ME,
             "cores": 1,
-            "coreLimit": "1",
             "memory": "2g",
             "tolerations": [],
             "volumeMounts": [],
@@ -113,7 +112,6 @@ SPARK_JOB_SPEC_TEMPLATE = {
             "instances": 2,
             "serviceAccount": OVERRIDE_ME,
             "cores": 2,
-            "coreLimit": "2",
             "memory": "4g",
             "tolerations": [],
             "volumeMounts": [],

--- a/airflow_spark_on_k8s_job_builder/core.py
+++ b/airflow_spark_on_k8s_job_builder/core.py
@@ -277,7 +277,7 @@ class SparkK8sJobBuilder(object):
         return self
 
     def get_driver_cores_limit(self):
-        return self.get_job_params()["driver"].get("coreLimit", None)
+        return self.get_job_params()["driver"].get("coreLimit")
 
     def set_driver_cores_limit(self, cores: Optional[int]) -> "SparkK8sJobBuilder":
         """Sets the number of driver cores."""
@@ -310,7 +310,7 @@ class SparkK8sJobBuilder(object):
         return self
 
     def get_executor_cores_limit(self):
-        return self.get_job_params()["executor"].get("coreLimit", None)
+        return self.get_job_params()["executor"].get("coreLimit")
 
     def set_executor_cores_limit(self, cores: Optional[int]) -> "SparkK8sJobBuilder":
         """Sets the number of executor cores."""

--- a/airflow_spark_on_k8s_job_builder/core.py
+++ b/airflow_spark_on_k8s_job_builder/core.py
@@ -271,18 +271,18 @@ class SparkK8sJobBuilder(object):
         if not cores:
             raise ValueError("Need to provide a non-empty value for the number of driver cores")
         self.get_job_params()["driver"]["cores"] = cores
-        min_max_cores = self._cast_cores_to_int(self.get_driver_cores(), self.get_driver_cores_limit(), "driver")
-        if min_max_cores[0] is not None and min_max_cores[1] is not None and min_max_cores[0] > min_max_cores[1]:
+        [requested_cores, max_cores] = self._cast_cores_to_int(self.get_driver_cores(), self.get_driver_cores_limit(), "driver")
+        if requested_cores is not None and max_cores is not None and requested_cores > max_cores:
             self.set_driver_cores_limit(cores)
         return self
 
     def get_driver_cores_limit(self):
-        return self.get_job_params()["driver"]["coreLimit"]
+        return self.get_job_params()["driver"].get("coreLimit", None)
 
-    def set_driver_cores_limit(self, cores: int) -> "SparkK8sJobBuilder":
+    def set_driver_cores_limit(self, cores: Optional[int]) -> "SparkK8sJobBuilder":
         """Sets the number of driver cores."""
-        if not cores:
-            raise ValueError("Need to provide a non-empty value for the number of driver cores")
+        if cores is not None and cores < 1:
+            raise ValueError("Driver core limit must be either None or at least 1")
         self.get_job_params()["driver"]["coreLimit"] = cores
         return self
 
@@ -304,18 +304,18 @@ class SparkK8sJobBuilder(object):
         if not cores:
             raise ValueError("Need to provide a non-empty value for the number of executor cores")
         self.get_job_params()["executor"]["cores"] = cores
-        min_max_cores = self._cast_cores_to_int(self.get_executor_cores(), self.get_executor_cores_limit(), "executor")
-        if min_max_cores[0] is not None and min_max_cores[1] is not None and min_max_cores[0] > min_max_cores[1]:
+        [requested_cores, cores_limit] = self._cast_cores_to_int(self.get_executor_cores(), self.get_executor_cores_limit(), "executor")
+        if requested_cores is not None and cores_limit is not None and requested_cores > cores_limit:
             self.set_executor_cores_limit(cores)
         return self
 
     def get_executor_cores_limit(self):
-        return self.get_job_params()["executor"]["coreLimit"]
+        return self.get_job_params()["executor"].get("coreLimit", None)
 
-    def set_executor_cores_limit(self, cores: int) -> "SparkK8sJobBuilder":
+    def set_executor_cores_limit(self, cores: Optional[int]) -> "SparkK8sJobBuilder":
         """Sets the number of executor cores."""
-        if not cores:
-            raise ValueError("Need to provide a non-empty (max) value for the number of executor cores")
+        if cores is not None and cores < 1:
+            raise ValueError("executor core limit must be None or at least 1")
         self.get_job_params()["executor"]["coreLimit"] = cores
         return self
 
@@ -589,18 +589,18 @@ class SparkK8sJobBuilder(object):
         self._validate_cores()
 
     def _validate_cores(self):
-        driver_cores = self._cast_cores_to_int(
+        driver_requested_cores, driver_core_limit = self._cast_cores_to_int(
             self.get_driver_cores(), self.get_driver_cores_limit(), "driver"
         )
-        if driver_cores[0] is not None and driver_cores[1] is not None \
-                and driver_cores[0] > driver_cores[1]:
+        if driver_requested_cores is not None and driver_core_limit is not None \
+                and driver_requested_cores > driver_core_limit:
             raise ValueError("Driver cores should be less than or equal to the limit of cores")
 
-        executor_cores = self._cast_cores_to_int(
+        executor_requested_cores, executor_core_limit = self._cast_cores_to_int(
             self.get_executor_cores(), self.get_executor_cores_limit(), "executor"
         )
-        if executor_cores[0] is not None and executor_cores[1] is not None \
-                and executor_cores[0] > executor_cores[1]:
+        if executor_requested_cores is not None and executor_core_limit is not None \
+                and executor_requested_cores > executor_core_limit:
             raise ValueError("Executor cores should be less than or equal to the limit of cores")
 
     @staticmethod
@@ -608,8 +608,8 @@ class SparkK8sJobBuilder(object):
         Optional[int], Optional[int]
     ]:
         try:
-            requested_cores = int(requested_cores)
-            max_cores = int(cores_limit)
+            requested_cores = int(requested_cores) if requested_cores is not None else None
+            max_cores = int(cores_limit) if cores_limit is not None else None
             return requested_cores, max_cores
         except ValueError as e:
             logging.warning(f"Unable to compare requested {node_type} cores against max {node_type}"

--- a/airflow_spark_on_k8s_job_builder/spark_k8s_template.yaml
+++ b/airflow_spark_on_k8s_job_builder/spark_k8s_template.yaml
@@ -42,7 +42,9 @@ spec:
     annotations: {{ params.driver.annotations }}
     {% endif %}
     cores: {{ params.driver.cores }}
+    {% if params.driver.coreLimit is defined and params.driver.coreLimit is not none %}
     coreLimit: "{{ params.driver.coreLimit }}"
+    {% endif %}
     memory: "{{ params.driver.memory }}"
     {% if params.driver.labels|length %}
     labels: {{ params.driver.labels }}
@@ -66,7 +68,9 @@ spec:
     {% endif %}
     cores: {{ params.executor.cores }}
     instances: {{ params.executor.instances }}
+    {% if params.executor.coreLimit is defined and params.executor.coreLimit is not none %}
     coreLimit: "{{ params.executor.coreLimit }}"
+    {% endif %}
     memory: "{{ params.executor.memory }}"
     {% if params.executor.tolerations|length %}
     tolerations: {{ params.executor.tolerations }}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -266,7 +266,7 @@ class TestSparkK8sJobBuilder(unittest.TestCase):
         self.assertEqual(expected, driver_cores)
 
         # then: It should not also automatically change cores limit
-        driver_cores_limit = driver.get('coreLimit', None)
+        driver_cores_limit = driver.get('coreLimit')
         self.assertEqual(None, driver_cores_limit, "core limit should not be set unless specifically requested")
 
 
@@ -309,7 +309,7 @@ class TestSparkK8sJobBuilder(unittest.TestCase):
         # then: It should correctly assign that value of cores
         self.assertEqual(expected, self.sut._job_spec['params']['executor']['cores'])
         # then: It should not also automatically change cores limit
-        self.assertEqual(None, self.sut._job_spec['params']['executor'].get('coreLimit', None))
+        self.assertEqual(None, self.sut._job_spec['params']['executor'].get('coreLimit'))
 
     def test_set_executor_cores_without_limit_should_produce_correct_spark_k8s_yaml_file(self):
         # given: The default spark k8s app file
@@ -335,7 +335,7 @@ class TestSparkK8sJobBuilder(unittest.TestCase):
         self.assertEqual(expected, executor_cores)
 
         # then: It should not also automatically change cores limit
-        executor_cores_limit = executor.get('coreLimit', None)
+        executor_cores_limit = executor.get('coreLimit')
         self.assertEqual(None, executor_cores_limit, "core limit should not be set unless specifically requested")
 
 
@@ -363,7 +363,7 @@ class TestSparkK8sJobBuilder(unittest.TestCase):
         self.assertEqual(expected, executor_cores, "executor requested cores should be set")
 
         # then: It should correctly set the cores limit
-        executor_cores_limit = executor.get('coreLimit', None)
+        executor_cores_limit = executor.get('coreLimit')
         self.assertEqual(str(expected + 10), executor_cores_limit, "executor core limit should be set")
 
     def test_set_executor_cores_limit_to_zero_should_fail(self):


### PR DESCRIPTION
Pod CPU limits are generally a bad thing. When they are in place, k8s attempts to throttle the pod to that limit. This can typically result in very poor utilisation of the node.

Take for example an executor pod that is configured with a hard limit of 2 cpus. It could be scheduled onto a node with the equivalent of 16 CPUs. However, due to the limit, it will only ever used the equivalent of 2 CPUs, leaving the bulk of the machine un-utilised.

We have also experienced issues where CPU limits cause instability or cause processes to crash. The performance hit of kernel throttled kernel scheduling is not brilliant.